### PR TITLE
Made custom REST name optional

### DIFF
--- a/lib/REST/init.php
+++ b/lib/REST/init.php
@@ -9,9 +9,11 @@ require( __DIR__ . '/limiter/Limiter.php' );
 remove_action( 'wp_head', 'rest_output_link_wp_head', 10 );
 remove_action( 'template_redirect', 'rest_output_link_header', 11, 0 );
 
-add_filter( 'rest_nonce_action', function() {
-	return STTV_REST_AUTH;
-});
+if ( has_filter( 'rest_nonce_action' ) ) {
+	add_filter( 'rest_nonce_action', function() {
+		return STTV_REST_AUTH;
+	});
+}
 
 function sttvlimiter() {
 	static $instance;

--- a/lib/scripts.php
+++ b/lib/scripts.php
@@ -138,13 +138,14 @@ function stajax_object() {
 					'public_key' => Spress()->public_key
 				)
 			);
-		if (is_singular('courses') || is_page('jobs')) {
-			$stajax['rest'] = array(
-				'ID' => $post->ID,
-				'nonce' => wp_create_nonce(STTV_REST_AUTH), 
-				'url' => rest_url(STTV_REST_NAMESPACE)
-			);
-		}
+			$nonce = has_filter( 'rest_nonce_action' ) ? STTV_REST_AUTH : 'wp_rest';
+			if (is_singular('courses') || is_page('jobs')) {
+				$stajax['rest'] = array(
+					'ID' => $post->ID,
+					'nonce' => wp_create_nonce( $nonce ), 
+					'url' => rest_url(STTV_REST_NAMESPACE)
+				);
+			}
 		?>
 		var stajax = <?php echo json_encode($stajax); ?>;
 	</script>


### PR DESCRIPTION
I altered a WP core file (wp-rest.php) to allow custom REST nonce names. I made a patch in the core trac, but until that patch is merged into core, creating a custom nonce name needs to be optional. It wasn't, but this commit fixes that.