### PR TITLE
Fixed REST route uncertainty

### DIFF
--- a/lib/courses.php
+++ b/lib/courses.php
@@ -11,12 +11,14 @@ function register_course_meta_endpoint() {
 	);
 
 	register_rest_route( STTV_REST_NAMESPACE , '/course_data/(?P<id>[\d]+)', [
-		'methods' => WP_REST_Server::READABLE,
-		'callback' => 'get_course_meta',
-		'permission_callback' => 'course_permissions_check',
-		'args' => [
-			'id' => [
-				'validate_callback' => 'absint'
+		[
+			'methods' => WP_REST_Server::READABLE,
+			'callback' => 'get_course_meta',
+			'permission_callback' => 'course_permissions_check',
+			'args' => [
+				'alert' => [
+					'required' => false
+				]
 			]
 		]
 	]);
@@ -36,7 +38,7 @@ function get_course_alert_template($data) {
 	$the_post = get_post($data['id']);
 	ob_start();
 	require(dirname(__DIR__).'/templates/courses/update_alert.php');
-	return array('html'=>ob_get_clean(),'hashid'=>sttvhashit($the_post->post_title.'/'.STTV_VERSION.'/'.$the_post->ID));
+	return [ 'html'=>ob_get_clean(),'hashid'=>sttvhashit($the_post->post_title.'/'.STTV_VERSION.'/'.$the_post->ID) ];
 }
 
 function course_permissions_check($data) {
@@ -54,6 +56,10 @@ function course_permissions_check($data) {
 }
 
 function get_course_meta($data) {
+	if ( isset($data['alert']) ){
+		return [ 'html'=>$data['id'], 'hashid'=>'0' ];
+		//return get_course_alert_template($data);
+	}
 	
 	$meta = get_post_meta( $data['id'], 'sttv_course_data' , true );
 	

--- a/single-courses.php
+++ b/single-courses.php
@@ -41,9 +41,8 @@ var student = {
 	
 var _st = {
 	request : function(obj) {
-		$.ajax({
+		var ajaxp = {
 			url: obj.route || '',
-			data: JSON.stringify(obj.cdata || {}),
 			method: obj.method || 'GET',
 			headers: obj.headers || {},
 			processData : false,
@@ -54,7 +53,11 @@ var _st = {
 			error: function(x,s,r){
 				typeof obj.error !== 'undefined' && obj.error([x,s,r]);
 			}
-		})
+		}
+		if (ajaxp.method !== 'GET') {
+			ajaxp['data'] = JSON.stringify(obj.cdata || {})
+		}
+		$.ajax(ajaxp)
 	},
 	loadTemplate : function(t) {
 		var part = t.part ? ' '+t.part : '';
@@ -115,7 +118,7 @@ var courses = {
 		},
 		request : function(cdata,method) {
 			$.ajax({
-				url: stajax.rest.url+'/course_data/'+stajax.rest.ID,
+				url: stajax.rest.url+'/course_data/'+stajax.rest.ID+'/',
 				data: cdata || null,
 				type: method || 'GET',
 				headers: {'X-WP-Nonce' : stajax.rest.nonce},
@@ -628,7 +631,7 @@ var courses = {
 			_st.request(
 				{
 					method : 'GET',
-				 	route : stajax.rest.url+'/course_data/'+stajax.rest.ID+'/alert',
+				 	route : stajax.rest.url+'/course_data/'+stajax.rest.ID+'?alert',
 					headers : {'X-WP-Nonce' : stajax.rest.nonce},
 				 	success : function(e){
 						typeof scb === 'function' && scb(e);


### PR DESCRIPTION
On a previous REST route update, the 'alert' argument for courses was a separate endpoint. It was accidentally eliminated in the last merge, causing 404 errors to the endpoint. The alert endpoint was added as an optional argument for the course request route.

Furthermore, in the javascript for the courses, an empty object was being appended to the uri, which may not cause any issues but the potential is there and it's bad practice. 